### PR TITLE
Fix updated fish package locations

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,2 +1,2 @@
-fisherman/git_util
-fisherman/last_job_id
+fishpkg/fish-git-util
+fishpkg/fish-last-job-id


### PR DESCRIPTION
When I ran `fisher add Geospace/slave` it complained about two missing packages. This seems to fix it.